### PR TITLE
Channels will now use id instead of displayMetadata.name

### DIFF
--- a/toolbox/fdc3-explained/1.2/main.js
+++ b/toolbox/fdc3-explained/1.2/main.js
@@ -42,9 +42,9 @@ async function populateHTML() {
     //populate available channels list with system channels
     let channelList = document.getElementById("system-channel-list");
 
-    const populateChannelsList = (name) => {
+    const populateChannelsList = (channelID) => {
       let node = document.createElement("li");
-      let textNode = document.createTextNode(name);
+      let textNode = document.createTextNode(channelID);
       node.appendChild(textNode);
       channelList.appendChild(node);
     }
@@ -52,11 +52,9 @@ async function populateHTML() {
     const systemChannels = await fdc3.getSystemChannels();
 
     // for all of the system channels populate dropdowns & lists
-    systemChannels.forEach(({ displayMetadata, id, type }) => {
-      let { name } = displayMetadata;
-      populateChannelsList(name)
-      populateChannelsDropDown(name)
-
+    systemChannels.forEach(({ id }) => {
+      populateChannelsList(id)
+      populateChannelsDropDown(id)
     });
 
     // set the versions of FDC3 Explained in the dropdown


### PR DESCRIPTION
displayMetadata.name was an optional field where id is mandatory. The code should not rely on optional fields and will now rely on the ids instead.